### PR TITLE
Fix runtime dir ownership checking.

### DIFF
--- a/src/xdg.rs
+++ b/src/xdg.rs
@@ -146,16 +146,10 @@ impl BaseDirectories
         // If XDG_RUNTIME_DIR is in the environment but not secure,
         // do not allow recovery.
         if let Some(ref runtime_dir) = runtime_dir {
-            match fs::metadata(runtime_dir) {
-                Err(_) => {
-                    panic!("$XDG_RUNTIME_DIR must be accessible by the current user");
-                }
-                Ok(metadata) => {
-                    if metadata.permissions().mode() & 0o077 != 0 {
-                        panic!("$XDG_RUNTIME_DIR must be secure: have permissions 0700");
-                    }
-                }
-            }
+            assert!(fs::read_dir(runtime_dir).is_ok(),
+                    "$XDG_RUNTIME_DIR must be accessible by the current user");
+            assert!(fs::metadata(runtime_dir).unwrap().permissions().mode() & 0o077 == 0,
+                    "$XDG_RUNTIME_DIR must be secure: have permissions 0700");
         }
 
         BaseDirectories {


### PR DESCRIPTION
You don’t need to own a directory to see its metadata:

```
<SimonSapin>	::std::fs::metadata("/root").is_ok()
<-->	playbot: true
<SimonSapin>	::std::fs::read_dir("/root").is_ok()
<-->	playbot: false
```

This is unfortunately hard to test: root access would be needed to change ownership of a directory under test_files/, and there is no guarantee any other directory would be present.