### PR TITLE
Fix compilation on OS X

### DIFF
--- a/src/xdg.rs
+++ b/src/xdg.rs
@@ -264,7 +264,7 @@ impl BaseDirectories
             }));
             let permissions = try!(fs::metadata(runtime_dir).map_err(|e| {
                 Error::new(XdgRuntimeDirInaccessible(runtime_dir.clone(), e))
-            })).permissions().mode();
+            })).permissions().mode() as u32;
             if permissions & 0o077 != 0 {
                 return Err(Error::new(XdgRuntimeDirInsecure(runtime_dir.clone(),
                                                             Permissions(permissions))));


### PR DESCRIPTION
```
src/xdg.rs:270:73: 270:84 error: mismatched types:
 expected `u32`,
    found `u16`
(expected u32,
    found u16) [E0308]
```

See https://travis-ci.org/rust-lang/cargo/jobs/98905090.