### PR TITLE
[WIP] menu-items and desktop-entry

### DIFF
--- a/src/desktop_entries.rs
+++ b/src/desktop_entries.rs
@@ -1,0 +1,15 @@
+use super::*;
+
+// This module implements menu-spec and desktop-entry
+
+pub trait DesktopEntries {
+    /// Returns a vector of all menu items according to
+    /// https://standards.freedesktop.org/menu-spec/1.1/
+    fn list_menu_items(&self) -> Vec<PathBuf>;
+}
+
+impl DesktopEntries for BaseDirectories {
+    fn list_menu_items(&self) -> Vec<PathBuf> {
+        self.list_data_files("applications")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ use std::os::unix::fs::PermissionsExt;
 use BaseDirectoriesErrorKind::*;
 use BaseDirectoriesError as Error;
 
+mod desktop_entries;
+pub use desktop_entries::DesktopEntries;
+
 /// BaseDirectories allows to look up paths to configuration, data,
 /// cache and runtime files in well-known locations according to
 /// the [X Desktop Group Base Directory specification][xdg-basedir].


### PR DESCRIPTION
I am trying to implement (at least part of) XDG [menu-items](https://standards.freedesktop.org/menu-spec/1.1/) and [desktop-entry](https://standards.freedesktop.org/desktop-entry-spec/latest/).

- Add method to retrieve all menu-items

I started a new `module` for desktop-entries and menu-items (they're pretty close together), I hope that's okay. Perhaps the `lib.rs` file should be split up too, in the future.