### PR TITLE
Redox support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg(any(unix, redox))]
+#![cfg(any(unix, target_os = "redox"))]
 
 use std::fmt;
 use std::convert;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg(unix)]
+#![cfg(any(unix, redox))]
 
 use std::fmt;
 use std::convert;


### PR DESCRIPTION
In the perfect world, rust would treat redox as unix.
But it doesn't.
Here you go.