### PR TITLE
maint: use dirs::home_dir() instead of deprecated std::env::home_dir()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ authors = [
 
 [lib]
 doctest = false
+
+[dependencies]
+dirs = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg(any(unix, target_os = "redox"))]
 
+extern crate dirs;
+
 use std::fmt;
 use std::convert;
 use std::error;
@@ -176,7 +178,7 @@ impl BaseDirectories {
     /// and returns a value that can be used for lookup.
     /// The following environment variables are examined:
     ///
-    ///   * `HOME`; if not set: use the same fallback as `std::env::home_dir()`;
+    ///   * `HOME`; if not set: use the same fallback as `dirs::home_dir()`;
     ///     if still not available: return an error.
     ///   * `XDG_DATA_HOME`; if not set: assumed to be `$HOME/.local/share`.
     ///   * `XDG_CONFIG_HOME`; if not set: assumed to be `$HOME/.config`.
@@ -253,7 +255,7 @@ impl BaseDirectories {
             }
         }
 
-        let home = try!(std::env::home_dir().ok_or(Error::new(HomeMissing)));
+        let home = try!(dirs::home_dir().ok_or(Error::new(HomeMissing)));
 
         let data_home   = env_var("XDG_DATA_HOME")
                               .and_then(abspath)


### PR DESCRIPTION
`cargo check` warns that std::env::home_dir() is deprecated:

    warning: use of deprecated item 'std::env::home_dir':
    This function's behavior is unexpected and probably not
    what you want. Consider using the home_dir function from
    https://crates.io/crates/dirs instead.

Use dirs::home_dir() instead.