### PR TITLE
Add `get_config_file`, etc. to provide paths without directory creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ rust:
   - stable
 env:
   - secure: "ZmdqljmHk9oOyCJWLKWJ4ayl/7rExqss+1ZIw26zeKontCdWQ9K5NvGmbk69mD9BL07aX1O1jIaSiSrqIqV6f8/BsguADvdBUyqfdLAXQy28we+17xTphmS6vh3uT1ayqGBBhB3Qy/6JnEBp5vFdcMbwSXq02+/MwCp/wbozk4junnJ0Gg0BOK/6FUQBBnlflg1Tm5KS3pZw5H7/7GtNRW4K9ApM6EBHqBhEc8GGemCoh6q2WUabSnaxev1Bql5ZogN7wDrf5Ohpvzqv5wU25aWwRc3eJngGRelHmlGtCS1VpWSZHE4nahWj6nLIsW6Kr620Dy2ZPvNuQ/+OCC/eKNPifRlgMN2Ff1eRz9irQ6sc+KCyDmaMpAA92f1IF7y9AolGKjiTWYxKMT+0g7lbPV+WoE1+pfbsZcyOGGMLxzxxlYxSukgXN55Eqs8ag9jakjP0GtCVU3tL4nO6zyq7+UhTleWPXuTKwG64C7q3UZZUgpayzzKcJdcCdozEwuokF/kI1+o4AiF65uFw+SrQ07okJnUm86p3QhRtNSdTY6hbbLGuELQ5DbikkKoavV8WdjjqViy4tU2WafdJvA67sZvEP4h6eVvAWz+/3uZoAJyXFbfulq40XB+Fzxl/5ionnM9md86UDsX9W64dSVl+2vovj+5Jejm3wQLsuJheVG4="
-before_script:
- - |
-   chmod 0700 test_files/user/runtime
 after_script:
   - |
     if [ "${TRAVIS_BRANCH}" = "master" -a -n "${GH_TOKEN}" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rust:
   - stable
 env:
   - secure: "ZmdqljmHk9oOyCJWLKWJ4ayl/7rExqss+1ZIw26zeKontCdWQ9K5NvGmbk69mD9BL07aX1O1jIaSiSrqIqV6f8/BsguADvdBUyqfdLAXQy28we+17xTphmS6vh3uT1ayqGBBhB3Qy/6JnEBp5vFdcMbwSXq02+/MwCp/wbozk4junnJ0Gg0BOK/6FUQBBnlflg1Tm5KS3pZw5H7/7GtNRW4K9ApM6EBHqBhEc8GGemCoh6q2WUabSnaxev1Bql5ZogN7wDrf5Ohpvzqv5wU25aWwRc3eJngGRelHmlGtCS1VpWSZHE4nahWj6nLIsW6Kr620Dy2ZPvNuQ/+OCC/eKNPifRlgMN2Ff1eRz9irQ6sc+KCyDmaMpAA92f1IF7y9AolGKjiTWYxKMT+0g7lbPV+WoE1+pfbsZcyOGGMLxzxxlYxSukgXN55Eqs8ag9jakjP0GtCVU3tL4nO6zyq7+UhTleWPXuTKwG64C7q3UZZUgpayzzKcJdcCdozEwuokF/kI1+o4AiF65uFw+SrQ07okJnUm86p3QhRtNSdTY6hbbLGuELQ5DbikkKoavV8WdjjqViy4tU2WafdJvA67sZvEP4h6eVvAWz+/3uZoAJyXFbfulq40XB+Fzxl/5ionnM9md86UDsX9W64dSVl+2vovj+5Jejm3wQLsuJheVG4="
+before_script:
+ - |
+   chmod 0700 test_files/user/runtime
 after_script:
   - |
     if [ "${TRAVIS_BRANCH}" = "master" -a -n "${GH_TOKEN}" ]; then

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -887,6 +887,12 @@ fn test_get_file() {
             ("XDG_CACHE_HOME", format!("{}/test_files/user/cache", cwd)),
             ("XDG_RUNTIME_DIR", format!("{}/test_files/user/runtime", cwd)),
         ])).unwrap();
+    
+    let path = format!("{}/test_files/user/runtime/", cwd);
+    let metadata = fs::metadata(&path).expect("Could not read metadata for runtime directory");
+    let mut perms = metadata.permissions();
+    &perms.set_mode(0o700);
+    fs::set_permissions(&path, perms);
 
     let file = xd.get_config_file("myapp/user_config.file");
     assert_eq!(file, PathBuf::from(&format!("{}/test_files/user/config/myapp/user_config.file", cwd)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -891,7 +891,7 @@ fn test_get_file() {
     let path = format!("{}/test_files/user/runtime/", cwd);
     let metadata = fs::metadata(&path).expect("Could not read metadata for runtime directory");
     let mut perms = metadata.permissions();
-    &perms.set_mode(0o700);
+    perms.set_mode(0o700);
     fs::set_permissions(&path, perms);
 
     let file = xd.get_config_file("myapp/user_config.file");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,6 +318,36 @@ impl BaseDirectories {
         }
     }
 
+    /// Like [`place_config_file()`](#method.place_config_file), but does
+    /// not create any directories.
+    pub fn get_config_file<P>(&self, path: P) -> PathBuf
+            where P: AsRef<Path> {
+        self.config_home.join(self.user_prefix.join(path))
+    }
+
+    /// Like [`place_data_file()`](#method.place_data_file), but does
+    /// not create any directories.
+    pub fn get_data_file<P>(&self, path: P) -> PathBuf
+            where P: AsRef<Path> {
+        self.data_home.join(self.user_prefix.join(path))
+    }
+
+    /// Like [`place_cache_file()`](#method.place_cache_file), but does
+    /// not create any directories.
+    pub fn get_cache_file<P>(&self, path: P) -> PathBuf
+            where P: AsRef<Path> {
+        self.cache_home.join(self.user_prefix.join(path))
+    }
+
+    /// Like [`place_runtime_file()`](#method.place_runtime_file), but does
+    /// not create any directories.
+    /// If `XDG_RUNTIME_DIR` is not available, returns an error.
+    pub fn get_runtime_file<P>(&self, path: P) -> io::Result<PathBuf>
+            where P: AsRef<Path> {
+        let runtime_dir = try!(self.get_runtime_directory());
+        Ok(runtime_dir.join(self.user_prefix.join(path)))
+    }
+
     /// Given a relative path `path`, returns an absolute path in
     /// `XDG_CONFIG_HOME` where a configuration file may be stored.
     /// Leading directories in the returned path are pre-created;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -884,6 +884,8 @@ fn test_prefix() {
             ("HOME", format!("{}/test_files/user", cwd)),
             ("XDG_CACHE_HOME", format!("{}/test_files/user/cache", cwd)),
         ])).unwrap();
+    assert_eq!(xd.get_cache_file("cache.db"),
+        PathBuf::from(&format!("{}/test_files/user/cache/myapp/cache.db", cwd)));
     assert_eq!(xd.place_cache_file("cache.db").unwrap(),
                PathBuf::from(&format!("{}/test_files/user/cache/myapp/cache.db", cwd)));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -878,6 +878,30 @@ fn test_lists() {
 }
 
 #[test]
+fn test_get_file() {
+    let cwd = env::current_dir().unwrap().to_string_lossy().into_owned();
+    let xd = BaseDirectories::with_env("", "", &*make_env(vec![
+            ("HOME", format!("{}/test_files/user", cwd)),
+            ("XDG_DATA_HOME", format!("{}/test_files/user/data", cwd)),
+            ("XDG_CONFIG_HOME", format!("{}/test_files/user/config", cwd)),
+            ("XDG_CACHE_HOME", format!("{}/test_files/user/cache", cwd)),
+            ("XDG_RUNTIME_DIR", format!("{}/test_files/user/runtime", cwd)),
+        ])).unwrap();
+
+    let file = xd.get_config_file("myapp/user_config.file");
+    assert_eq!(file, PathBuf::from(&format!("{}/test_files/user/config/myapp/user_config.file", cwd)));
+
+    let file = xd.get_data_file("user_data.file");
+    assert_eq!(file, PathBuf::from(&format!("{}/test_files/user/data/user_data.file", cwd)));
+
+    let file = xd.get_cache_file("user_cache.file");
+    assert_eq!(file, PathBuf::from(&format!("{}/test_files/user/cache/user_cache.file", cwd)));
+
+    let file = xd.get_runtime_file("user_runtime.file").unwrap();
+    assert_eq!(file, PathBuf::from(&format!("{}/test_files/user/runtime/user_runtime.file", cwd)));
+}
+
+#[test]
 fn test_prefix() {
     let cwd = env::current_dir().unwrap().to_string_lossy().into_owned();
     let xd = BaseDirectories::with_env("myapp", "", &*make_env(vec![


### PR DESCRIPTION
This PR creates some variants on the `place_*_file` functions, which should behave the same except that they will have no side effects (directory creation).