### PR TITLE
Reduce warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,7 +571,7 @@ fn write_file<P>(home: &PathBuf, path: P) -> io::Result<PathBuf>
 fn create_directory<P>(home: &PathBuf, path: P) -> io::Result<PathBuf>
         where P: AsRef<Path> {
     let full_path = home.join(path.as_ref());
-    fs::create_dir_all(&full_path);
+    fs::create_dir_all(&full_path)?;
     Ok(full_path)
 }
 


### PR DESCRIPTION
Thanks for reviewing the last PR. This one just reduces the warnings output by `cargo check`, either by adding a `?` to use a result or by replacing the `try!`s throughout with the equivalent `?`s.