### PR TITLE
Add public XDG_RUNTIME_DIR method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,8 @@ impl BaseDirectories {
         })
     }
 
-    fn get_runtime_directory(&self) -> Result<&PathBuf, BaseDirectoriesError> {
+    /// Returns the user-specific runtime directory (set by `XDG_RUNTIME_DIR`).
+    pub fn get_runtime_directory(&self) -> Result<&PathBuf, BaseDirectoriesError> {
         if let Some(ref runtime_dir) = self.runtime_dir {
             // If XDG_RUNTIME_DIR is in the environment but not secure,
             // do not allow recovery.


### PR DESCRIPTION
This changes the visibility of the existing `get_runtime_directory`
method to `pub` to make it possible for consumers to find that directory
without requiring access to a specific file.

The documentation has been adjusted to match existing directory access
methods.

Fixes #35.