### PR TITLE
cargo: Bump dirs to 4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ authors = [
 doctest = false
 
 [dependencies]
-dirs = "3.0"
+dirs = "4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -946,7 +946,7 @@ fn test_get_file() {
             ("XDG_CACHE_HOME", format!("{}/test_files/user/cache", cwd)),
             ("XDG_RUNTIME_DIR", format!("{}/test_files/user/runtime", cwd)),
         ])).unwrap();
-    
+
     let path = format!("{}/test_files/user/runtime/", cwd);
     let metadata = fs::metadata(&path).expect("Could not read metadata for runtime directory");
     let mut perms = metadata.permissions();


### PR DESCRIPTION
A newer version of `dirs` is available.

Since this crate is not exposed in public API this change can probably be a patch-release?
