### PR TITLE
Fix infinite recursion in `impl Display for BaseDirectoriesError`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ impl error::Error for BaseDirectoriesError {
 impl fmt::Display for BaseDirectoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.kind {
-            HomeMissing => write!(f, "{}", self.to_string()),
+            HomeMissing => write!(f, "$HOME must be set"),
             XdgRuntimeDirInaccessible(ref dir, ref error) => {
                 write!(f, "$XDG_RUNTIME_DIR (`{}`) must be accessible \
                            by the current user (error: {})", dir.display(), error)


### PR DESCRIPTION
Hi!

I was randomly reading your code, when something catched my eye.

Since the trait `ToString` rely on the implementation of `Display`, calling `self.to_string()` inside a `Display` implementation result in an infinite loop.

I confirmed it through experimentation then implemented a simple fix.