### PR TITLE
derive serialize and deserialize for BaseDirectories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ authors = [
 [lib]
 doctest = false
 
+[features]
+serde = ["dep:serde"]
+
 [dependencies]
 dirs = "4.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "*", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ doctest = false
 
 [dependencies]
 dirs = "4.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg(any(unix, target_os = "redox"))]
 
 extern crate dirs;
+#[cfg(feature = "serde")]
 extern crate serde;
 
 use std::fmt;
@@ -14,6 +15,7 @@ use std::ffi::OsString;
 
 use std::os::unix::fs::PermissionsExt;
 
+#[cfg(feature = "serde")]
 use serde::{Serialize, Deserialize};
 
 use BaseDirectoriesErrorKind::*;
@@ -75,7 +77,8 @@ use BaseDirectoriesError as Error;
 /// The `logo.png` will be searched in the proper locations for
 /// supplementary data files, most likely `~/.local/share/myapp/logo.png`,
 /// then `/usr/local/share/myapp/logo.png` and `/usr/share/myapp/logo.png`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BaseDirectories {
     shared_prefix: PathBuf,
     user_prefix: PathBuf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg(any(unix, target_os = "redox"))]
 
 extern crate dirs;
+extern crate serde;
 
 use std::fmt;
 use std::convert;
@@ -12,6 +13,8 @@ use std::path::{Path, PathBuf};
 use std::ffi::OsString;
 
 use std::os::unix::fs::PermissionsExt;
+
+use serde::{Serialize, Deserialize};
 
 use BaseDirectoriesErrorKind::*;
 use BaseDirectoriesError as Error;
@@ -72,7 +75,7 @@ use BaseDirectoriesError as Error;
 /// The `logo.png` will be searched in the proper locations for
 /// supplementary data files, most likely `~/.local/share/myapp/logo.png`,
 /// then `/usr/local/share/myapp/logo.png` and `/usr/share/myapp/logo.png`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BaseDirectories {
     shared_prefix: PathBuf,
     user_prefix: PathBuf,


### PR DESCRIPTION
It would be nice if this could somehow be optional but I'm not aware of a way to derive only if a crate feature.