### PR TITLE
Enable doctests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,6 @@ authors = [
     "whitequark <whitequark@whitequark.org>"
 ]
 
-[lib]
-doctest = false
-
 [features]
 serde = ["dep:serde"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,10 +54,17 @@ use BaseDirectoriesError as Error;
 /// To store configuration:
 ///
 /// ```
+/// # extern crate xdg;
+/// # use std::fs::File;
+/// # use std::io::{Error, Write};
+/// # fn main() -> Result<(), Error> {
+/// # let xdg_dirs = xdg::BaseDirectories::with_prefix("myapp").unwrap();
 /// let config_path = xdg_dirs.place_config_file("config.ini")
 ///                           .expect("cannot create configuration directory");
 /// let mut config_file = File::create(config_path)?;
 /// write!(&mut config_file, "configured = 1")?;
+/// #   Ok(())
+/// # }
 /// ```
 ///
 /// The `config.ini` file will appear in the proper location for desktop
@@ -66,12 +73,19 @@ use BaseDirectoriesError as Error;
 ///
 /// To retrieve supplementary data:
 ///
-/// ```
+/// ```no_run
+/// # extern crate xdg;
+/// # use std::fs::File;
+/// # use std::io::{Error, Read, Write};
+/// # fn main() -> Result<(), Error> {
+/// # let xdg_dirs = xdg::BaseDirectories::with_prefix("myapp").unwrap();
 /// let logo_path = xdg_dirs.find_data_file("logo.png")
 ///                         .expect("application data not present");
 /// let mut logo_file = File::open(logo_path)?;
 /// let mut logo = Vec::new();
 /// logo_file.read_to_end(&mut logo)?;
+/// #   Ok(())
+/// # }
 /// ```
 ///
 /// The `logo.png` will be searched in the proper locations for
@@ -221,7 +235,9 @@ impl BaseDirectories {
     ///
     /// For example:
     ///
-    /// ```rust
+    /// ```
+    /// # extern crate xdg;
+    /// # use xdg::BaseDirectories;
     /// let dirs = BaseDirectories::with_profile("program-name", "profile-name")
     ///                            .unwrap();
     /// dirs.find_data_file("bar.jpg");


### PR DESCRIPTION
The doctests can be enabled by adding the necessary initialization code and hiding it with a leading `#`.