### PR TITLE
Reduce MSRV and add a MSRV build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+env:
+  minrust: 1.27.2
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -10,4 +13,15 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo check --features serde
+      - run: cargo test
+
+  MSRV:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install ${{ env.minrust }} toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.minrust }}
       - run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,6 @@ authors = [
     "whitequark <whitequark@whitequark.org>"
 ]
 
-[features]
-serde = ["dep:serde"]
-
 [dependencies]
 dirs = "4.0"
 serde = { version = "*", features = ["derive"], optional = true }


### PR DESCRIPTION
The namespaced features with the `dep` prefix was stabilized with 1.60, and the MSRV can be reduced to 1.27.2 by avoiding it.

It's not necessary to define a feature to enable a single optional dependencies.

The build job makes it possible to keep the MSRV in check and bump the version deliberately when needed.