### PR TITLE
Use Rust edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ homepage = "https://github.com/whitequark/rust-xdg"
 repository = "https://github.com/whitequark/rust-xdg"
 documentation = "https://docs.rs/xdg/"
 readme = "README.md"
+edition = "2018"
 keywords = ["linux", "configuration"]
 license = "Apache-2.0/MIT"
 authors = [

--- a/src/base_directories.rs
+++ b/src/base_directories.rs
@@ -4,7 +4,6 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::{env, error, fmt, fs, io};
 
-use home;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -36,14 +35,12 @@ use self::ErrorKind::*;
 /// To configure paths for application `myapp`:
 ///
 /// ```
-/// extern crate xdg;
 /// let xdg_dirs = xdg::BaseDirectories::with_prefix("myapp").unwrap();
 /// ```
 ///
 /// To store configuration:
 ///
 /// ```
-/// # extern crate xdg;
 /// # use std::fs::File;
 /// # use std::io::{Error, Write};
 /// # fn main() -> Result<(), Error> {
@@ -64,7 +61,6 @@ use self::ErrorKind::*;
 /// To retrieve supplementary data:
 ///
 /// ```no_run
-/// # extern crate xdg;
 /// # use std::fs::File;
 /// # use std::io::{Error, Read, Write};
 /// # fn main() -> Result<(), Error> {
@@ -107,7 +103,7 @@ impl Error {
 }
 
 impl fmt::Debug for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.kind.fmt(f)
     }
 }
@@ -132,7 +128,7 @@ impl error::Error for Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
             HomeMissing => write!(f, "$HOME must be set"),
             XdgRuntimeDirInaccessible(ref dir, ref error) => {
@@ -173,14 +169,14 @@ impl From<Error> for io::Error {
 struct Permissions(u32);
 
 impl fmt::Debug for Permissions {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Permissions(p) = *self;
         write!(f, "{:#05o}", p)
     }
 }
 
 impl fmt::Display for Permissions {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self, f)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 #![cfg(any(unix, target_os = "redox"))]
 
-extern crate home;
-#[cfg(feature = "serde")]
-extern crate serde;
-
 mod base_directories;
-pub use base_directories::{BaseDirectories, Error as BaseDirectoriesError, FileFindIterator};
+pub use crate::base_directories::{
+    BaseDirectories, Error as BaseDirectoriesError, FileFindIterator,
+};


### PR DESCRIPTION
The Rust edition can be changed to `2018` because the `home` dependency forced the MSRV of 1.31.