### PR TITLE
Add support for missing $HOME

### DIFF
--- a/src/base_directories.rs
+++ b/src/base_directories.rs
@@ -693,6 +693,12 @@ impl BaseDirectories {
     }
 }
 
+impl Default for BaseDirectories {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 fn write_file(home: &Path, path: &Path) -> io::Result<PathBuf> {
     match path.parent() {
         Some(parent) => fs::create_dir_all(home.join(parent))?,

--- a/src/base_directories.rs
+++ b/src/base_directories.rs
@@ -428,7 +428,7 @@ impl BaseDirectories {
     /// `XDG_CONFIG_DIRS`.
     pub fn find_config_file<P: AsRef<Path>>(&self, path: P) -> Option<PathBuf> {
         read_file(
-            self.config_home.as_deref(),
+            self.config_home.as_ref().map(|home| home.as_path()),
             &self.config_dirs,
             &self.user_prefix,
             &self.shared_prefix,
@@ -442,7 +442,7 @@ impl BaseDirectories {
     /// to highest.
     pub fn find_config_files<P: AsRef<Path>>(&self, path: P) -> FileFindIterator {
         FileFindIterator::new(
-            self.config_home.as_deref(),
+            self.config_home.as_ref().map(|home| home.as_path()),
             &self.config_dirs,
             &self.user_prefix,
             &self.shared_prefix,
@@ -455,7 +455,7 @@ impl BaseDirectories {
     /// `XDG_DATA_DIRS`.
     pub fn find_data_file<P: AsRef<Path>>(&self, path: P) -> Option<PathBuf> {
         read_file(
-            self.data_home.as_deref(),
+            self.data_home.as_ref().map(|home| home.as_path()),
             &self.data_dirs,
             &self.user_prefix,
             &self.shared_prefix,
@@ -469,7 +469,7 @@ impl BaseDirectories {
     /// to highest.
     pub fn find_data_files<P: AsRef<Path>>(&self, path: P) -> FileFindIterator {
         FileFindIterator::new(
-            self.data_home.as_deref(),
+            self.data_home.as_ref().map(|home| home.as_path()),
             &self.data_dirs,
             &self.user_prefix,
             &self.shared_prefix,
@@ -481,7 +481,7 @@ impl BaseDirectories {
     /// cache file, or `None`. Searches `XDG_CACHE_HOME`.
     pub fn find_cache_file<P: AsRef<Path>>(&self, path: P) -> Option<PathBuf> {
         read_file(
-            self.cache_home.as_deref(),
+            self.cache_home.as_ref().map(|home| home.as_path()),
             &Vec::new(),
             &self.user_prefix,
             &self.shared_prefix,
@@ -493,7 +493,7 @@ impl BaseDirectories {
     /// application state file, or `None`. Searches `XDG_STATE_HOME`.
     pub fn find_state_file<P: AsRef<Path>>(&self, path: P) -> Option<PathBuf> {
         read_file(
-            self.state_home.as_deref(),
+            self.state_home.as_ref().map(|home| home.as_path()),
             &Vec::new(),
             &self.user_prefix,
             &self.shared_prefix,
@@ -520,25 +520,37 @@ impl BaseDirectories {
     /// leading to it are created if they did not exist;
     /// if that is not possible, an error is returned.
     pub fn create_config_directory<P: AsRef<Path>>(&self, path: P) -> io::Result<PathBuf> {
-        create_directory(self.config_home.as_deref(), &self.user_prefix.join(path))
+        create_directory(
+            self.config_home.as_ref().map(|home| home.as_path()),
+            &self.user_prefix.join(path),
+        )
     }
 
     /// Like [`create_config_directory()`](#method.create_config_directory),
     /// but for a data directory in `XDG_DATA_HOME`.
     pub fn create_data_directory<P: AsRef<Path>>(&self, path: P) -> io::Result<PathBuf> {
-        create_directory(self.data_home.as_deref(), &self.user_prefix.join(path))
+        create_directory(
+            self.data_home.as_ref().map(|home| home.as_path()),
+            &self.user_prefix.join(path),
+        )
     }
 
     /// Like [`create_config_directory()`](#method.create_config_directory),
     /// but for a cache directory in `XDG_CACHE_HOME`.
     pub fn create_cache_directory<P: AsRef<Path>>(&self, path: P) -> io::Result<PathBuf> {
-        create_directory(self.cache_home.as_deref(), &self.user_prefix.join(path))
+        create_directory(
+            self.cache_home.as_ref().map(|home| home.as_path()),
+            &self.user_prefix.join(path),
+        )
     }
 
     /// Like [`create_config_directory()`](#method.create_config_directory),
     /// but for an application state directory in `XDG_STATE_HOME`.
     pub fn create_state_directory<P: AsRef<Path>>(&self, path: P) -> io::Result<PathBuf> {
-        create_directory(self.state_home.as_deref(), &self.user_prefix.join(path))
+        create_directory(
+            self.state_home.as_ref().map(|home| home.as_path()),
+            &self.user_prefix.join(path),
+        )
     }
 
     /// Like [`create_config_directory()`](#method.create_config_directory),
@@ -556,7 +568,7 @@ impl BaseDirectories {
     /// `XDG_CONFIG_DIRS`.
     pub fn list_config_files<P: AsRef<Path>>(&self, path: P) -> Vec<PathBuf> {
         list_files(
-            self.config_home.as_deref(),
+            self.config_home.as_ref().map(|home| home.as_path()),
             &self.config_dirs,
             &self.user_prefix,
             &self.shared_prefix,
@@ -568,7 +580,7 @@ impl BaseDirectories {
     /// only the first occurence of every distinct filename is returned.
     pub fn list_config_files_once<P: AsRef<Path>>(&self, path: P) -> Vec<PathBuf> {
         list_files_once(
-            self.config_home.as_deref(),
+            self.config_home.as_ref().map(|home| home.as_path()),
             &self.config_dirs,
             &self.user_prefix,
             &self.shared_prefix,
@@ -581,7 +593,7 @@ impl BaseDirectories {
     /// `XDG_DATA_DIRS`.
     pub fn list_data_files<P: AsRef<Path>>(&self, path: P) -> Vec<PathBuf> {
         list_files(
-            self.data_home.as_deref(),
+            self.data_home.as_ref().map(|home| home.as_path()),
             &self.data_dirs,
             &self.user_prefix,
             &self.shared_prefix,
@@ -593,7 +605,7 @@ impl BaseDirectories {
     /// only the first occurence of every distinct filename is returned.
     pub fn list_data_files_once<P: AsRef<Path>>(&self, path: P) -> Vec<PathBuf> {
         list_files_once(
-            self.data_home.as_deref(),
+            self.data_home.as_ref().map(|home| home.as_path()),
             &self.data_dirs,
             &self.user_prefix,
             &self.shared_prefix,
@@ -605,7 +617,7 @@ impl BaseDirectories {
     /// in directories with path `path` in `XDG_CACHE_HOME`.
     pub fn list_cache_files<P: AsRef<Path>>(&self, path: P) -> Vec<PathBuf> {
         list_files(
-            self.cache_home.as_deref(),
+            self.cache_home.as_ref().map(|home| home.as_path()),
             &Vec::new(),
             &self.user_prefix,
             &self.shared_prefix,
@@ -617,7 +629,7 @@ impl BaseDirectories {
     /// in directories with path `path` in `XDG_STATE_HOME`.
     pub fn list_state_files<P: AsRef<Path>>(&self, path: P) -> Vec<PathBuf> {
         list_files(
-            self.state_home.as_deref(),
+            self.state_home.as_ref().map(|home| home.as_path()),
             &Vec::new(),
             &self.user_prefix,
             &self.shared_prefix,


### PR DESCRIPTION
Move failures to call time rather than `BaseDirectories` creation.

This means, for instance, that `create_config_directory()` can work if `XDG_CONFIG_HOME` is defined even if `HOME` isn't.

This also means that methods like `find_data_file()` and `find_config_file()` will work without a home directory, which can be useful for software that wants to support both use by regular users and use by system accounts without
`HOME`.

I tried to write a test case, but `std::env::home_dir()` will figure out the home dir even if `HOME` is unset, which makes meaningful testing quite difficult.