### PR TITLE
Make fields of `BaseDirectories` public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 env:
-  minrust: 1.36.0
+  minrust: 1.40.0 # Also update in Cargo.toml
 
 jobs:
   Lints:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/whitequark/rust-xdg"
 documentation = "https://docs.rs/xdg/"
 readme = "README.md"
 edition = "2018"
+rust-version = "1.40.0" # Also update in .github/workflows/ci.yml
 categories = ["filesystem"]
 keywords = ["linux", "configuration"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
Closes #44.

I was initially aiming for making `with_env` public, but then I noticed that the struct has minimal invariants, so its fields can be made public. Also added some documentation to make more clear which variable contains what exactly, as the prefixes make this somewhat non-obvious.

While doing this I also noted a slight inconsistency: `get_runtime_directory` does not add any prefixes, however the `get_XXX_home` functions do. Changing this would require a backwards incompatible change however.